### PR TITLE
Show request failures

### DIFF
--- a/src/components/content/Request.css
+++ b/src/components/content/Request.css
@@ -1,0 +1,3 @@
+.reason {
+  font-size: .75rem;
+}

--- a/src/components/content/Request.js
+++ b/src/components/content/Request.js
@@ -2,34 +2,49 @@ import React from 'react'
 import Button from 'react-bootstrap/Button'
 import axios from 'axios'
 import apiConfig from '../../apiConfig'
+import './Request.css';
 
+const RequestMessage = ({requestMessage }) => {
+  return (
+  <div className={requestMessage.success ? "alert alert-success" : "alert alert-danger"}>
+    <strong>{ requestMessage.message }</strong>
+    { requestMessage.reason ? <span className="reason"><br />{ requestMessage.reason }</span> : "" }
+  </div> )
+}
 
 const Request = props => {
-  const [requestMessage, setRequestMessage] = React.useState("");
+  const [requestMessage, setRequestMessage] = React.useState({});
 
   const requestSong = () => {
     axios({ url: `${apiConfig.apiUrl}/station/${apiConfig.stationId}/request/${props.requestId}`,
       method: 'POST',
     })
       .then(res => {
-        setRequestMessage(res.data.message)
-      }, res => {
-        setRequestMessage("Request failed!")
+        setRequestMessage({
+          success: true,
+          message: "✔️ " + res.data.message,
+          reason: "",
+        })
+      }, (err) => {
+        setRequestMessage({
+          success: false,
+          message: "❌ Request failed!",
+          reason: err.response.data.message,
+        })
       })
       .catch(console.error)
   }
-
-
-
   return (
-    requestMessage === "" ?
-      <Button
-        className="request-button"
-        variant="success"
-        onClick={requestSong}
-      >request</Button> :
-      <span>{ requestMessage }</span>
-
+    <div>
+      {
+        !requestMessage.message ?
+        <Button
+          className="request-button"
+          variant="success"
+          onClick={requestSong}
+        >request</Button> : <RequestMessage requestMessage={requestMessage} />
+      }
+    </div>
   )
 }
 

--- a/src/components/content/SongList.css
+++ b/src/components/content/SongList.css
@@ -7,11 +7,6 @@
   text-align: left;
 }
 
-.song-info {
-  width: 500px;
-  float: left;
-}
-
 .song-album {
   font-size: small;
 }


### PR DESCRIPTION
Request failures previously just showed that they failed. This feature introduces bootstrap themed success and failure messages.
<img width="1124" alt="Screen Shot 2020-10-11 at 2 43 46 PM" src="https://user-images.githubusercontent.com/430386/95687219-4eea1980-0bd0-11eb-8115-4d7926637462.png">
<img width="585" alt="Screen Shot 2020-10-11 at 2 44 00 PM" src="https://user-images.githubusercontent.com/430386/95687220-4eea1980-0bd0-11eb-892a-6cfa80ea0ab2.png">

